### PR TITLE
Add news submodule and sidebar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "research"]
 	path = research
 	url = https://github.com/ucsdwcsng/site-research-pages
+[submodule "_data/news"]
+	path = _data/news
+	url = https://github.com/ucsdwcsng/site-news-page

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -1,0 +1,10 @@
+<div class="news">
+  <h2>News</h2>
+
+  {% for article in site.data.news.news limit:9 %}
+  <i><font color="gray">{{ article.date }}</font></i>
+  <p>{{ article.headline }}</p>
+  {% endfor %}
+
+  <a href="/news">More news...</a>
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -184,9 +184,15 @@ sidebar:
 
               <div class="col-aside d-print-none js-col-aside">
                 {%- if page.aside -%}
+                {% if page.aside.toc %}
                   <aside class="page__aside js-page-aside">
                     {%- include aside/toc.html -%}
                   </aside>
+                {% else if page.aside.news %}
+                  <aside class="page__aside">
+                    {%- include news.html -%}
+                  </aside>
+                {% endif %}
                 {%- endif -%}
               </div>
 

--- a/_sass/common/_variables.scss
+++ b/_sass/common/_variables.scss
@@ -84,7 +84,7 @@ $layout: (
   content-max-width:      950px,
   sidebar-width:          250px,
   sidebar-header-height:  3rem,
-  aside-width:            220px
+  aside-width:            320px
 );
 
 //     sm       md       lg

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -1,3 +1,10 @@
 /* start custom scss snippet */
 
+.news {
+  border: 1px solid black;
+  padding: 10px;
+  margin: 16px;
+  margin-top: 52px;
+}
+
 /* end custom scss snippet */

--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 ---
 layout: article
+aside:
+  news: true
 title: Wireless Communications Sensing and Networking
 carousels:
   - images:

--- a/news.md
+++ b/news.md
@@ -1,0 +1,10 @@
+---
+title: "News"
+layout: article
+permalink: /news.html
+---
+
+{% for article in site.data.news.news %}
+<p><i><font color="gray">{{ article.date }}</font></i><br>
+{{ article.headline }}</p>
+{% endfor %}


### PR DESCRIPTION
The data for news is in the same format as the existing wcsng.ucsd.edu website and stored in the `ucsdwcsng/site-news-page` repository which is linked as a submodule at `_data/news/`.